### PR TITLE
refactor: Support Astro v5

### DIFF
--- a/packages/astro-fuse/package.json
+++ b/packages/astro-fuse/package.json
@@ -67,7 +67,7 @@
     "vite": "^5.3.4"
   },
   "peerDependencies": {
-    "astro": "^4.8.0",
+    "astro": ">=4.8.0",
     "fuse.js": "^7.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
In my Astro v5 project I have conflicting peer dependencies because astro-fuse requires Astro v5:

> peer astro@"^4.8.0" from astro-fuse@1.0.1

Let's allow any Astro version 4.8.0 and above.